### PR TITLE
feature: seperate the init and add command

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -12,12 +12,19 @@ import { version } from "../package.json"
 import * as util from "../src/utilities/cliUtil"
 
 async function handleInitCommand() {
-  const editedSam = <string>(<unknown>await util.confirmation())
+  const editedSam = <string>(<unknown>await util.initConfirmation())
   if (editedSam === "create new SAM project") {
     await createSAMCLI()
   } else if (editedSam === "create custom SAM project") {
     await createCustomSAMCLI()
-  } else if (editedSam === "add components to existing SAM") {
+  } else {
+    console.log(editedSam)
+    throw new Error(`Unknown option ${editedSam}`)
+  }
+}
+async function handleAddCommand() {
+  const editedSam = <string>(<unknown>await util.addConfirmation())
+  if (editedSam === "add components to existing SAM") {
     await addComponentCLI()
   } else if (editedSam === "add modules to existing SAM") {
     await addModuleCLI()
@@ -48,6 +55,9 @@ async function run(argv: Array<string>): Promise<void> {
     switch (argv[0]) {
       case "init":
         await handleInitCommand()
+        break
+      case "add":
+        await handleAddCommand()
         break
       case "deploy":
         await handleDeployCommand()

--- a/scripts/exec.sh
+++ b/scripts/exec.sh
@@ -1,2 +1,2 @@
 sam build
-sam deploy --no-confirm-changeset --capabilities CAPABILITY_NAMED_IAM CAPABILITY_IAM CAPABILITY_AUTO_EXPAND --stack-name $2 --region $3 --profile $5  $4
+sam deploy --no-confirm-changeset --capabilities CAPABILITY_NAMED_IAM CAPABILITY_IAM CAPABILITY_AUTO_EXPAND --stack-name $2 --profile $3  --region $4  $5

--- a/src/configs/buildConfig.ts
+++ b/src/configs/buildConfig.ts
@@ -4,7 +4,7 @@ export const samConfig: Record<
 > = {
   choices: {
     tool: ["GitHub", "GitLab", "BitBucket"],
-    language: ["js", "python"],
+    language: ["js"],
     framework: ["sam", "cdk"],
     deploymentregion: [
       "us-east-2",

--- a/src/configs/cliConfig.ts
+++ b/src/configs/cliConfig.ts
@@ -41,7 +41,7 @@ export const app: Record<
   choices: {
     methods: ["put", "get", "post", "delete"],
     resourcetype: ["lambda", "stepfunction", "dynamodb"],
-    language: ["Node", "Python"],
+    language: ["Node"],
     type: Object.values(moduleDescription),
     pipeline: ["generate pipeline", "cli", "repository and pipeline"],
   },

--- a/src/roverCLI/roverDeployCLI.ts
+++ b/src/roverCLI/roverDeployCLI.ts
@@ -70,7 +70,7 @@ export async function deployCLI() {
     const region = deploymentregion["Deployment region"]
 
     exec(
-      `sh ${roverHelpers.npmroot}/@rover-tools/cli/scripts/exec.sh ${fileName} ${stack_name} ${region} ${bucketName} ${profile} `
+      `sh ${roverHelpers.npmroot}/@rover-tools/cli/scripts/exec.sh ${fileName} ${stack_name} ${profile} ${region}  ${bucketName}`
     )
 
     const configdata: IroverDeploymentConfig = <IroverDeploymentConfig>{}

--- a/src/roverCLI/roverGenerateCLI.ts
+++ b/src/roverCLI/roverGenerateCLI.ts
@@ -1,6 +1,7 @@
 import * as rover from "@rover-tools/engine/dist/bin/index"
 const roverHelpers = rover.helpers
-const rover_addComponent = rover.addComponents
+//const rover_addComponent = rover.addComponents
+const rover_addComponent = rover.addComponent
 const rover_addModules = rover.addModules
 const rover_generateSAM = rover.generateSAM
 const rover_addModulesToexisting = rover.addModulesToExisting

--- a/src/utilities/cliUtil.ts
+++ b/src/utilities/cliUtil.ts
@@ -71,20 +71,13 @@ export async function inputString(
             (value !== "" && value !== undefined) ||
             "Environment values cannot be empty"
           )
+        } else {
+          return (
+            optional ||
+            stringpattern.test(value) ||
+            `${message} ${name} ${value} should have only alphanumeric values `
+          )
         }
-        // return (
-        //   optional ||
-        //   stringpattern.test(value) ||
-        //   `${typeof message} ${typeof value} ${typeof optional} ${typeof stringpattern.test(
-        //     value
-        //   )} should have only alphanumeric values `
-        // )
-        return (
-          optional ||
-          (!stringpattern.test(value)
-            ? `should have only alphanumeric values`
-            : true)
-        )
       },
     },
   ])

--- a/src/utilities/cliUtil.ts
+++ b/src/utilities/cliUtil.ts
@@ -71,13 +71,20 @@ export async function inputString(
             (value !== "" && value !== undefined) ||
             "Environment values cannot be empty"
           )
-        } else {
-          return (
-            optional ||
-            stringpattern.test(value) ||
-            `${message} should have only alphanumeric values`
-          )
         }
+        // return (
+        //   optional ||
+        //   stringpattern.test(value) ||
+        //   `${typeof message} ${typeof value} ${typeof optional} ${typeof stringpattern.test(
+        //     value
+        //   )} should have only alphanumeric values `
+        // )
+        return (
+          optional ||
+          (!stringpattern.test(value)
+            ? `should have only alphanumeric values`
+            : true)
+        )
       },
     },
   ])
@@ -134,15 +141,25 @@ export const inputType = async function (
   return takeInput
 }
 
-export const confirmation = async function () {
+export const initConfirmation = async function () {
+  const r = await inquirer.prompt([
+    {
+      type: "rawlist",
+      name: "choice",
+      message: `Hey, what do you want ?`,
+      choices: ["create new SAM project", "create custom SAM project"],
+    },
+  ])
+
+  return r.choice
+}
+export const addConfirmation = async function () {
   const r = await inquirer.prompt([
     {
       type: "rawlist",
       name: "choice",
       message: `Hey, what do you want ?`,
       choices: [
-        "create new SAM project",
-        "create custom SAM project",
         "add components to existing SAM",
         "add modules to existing SAM",
       ],


### PR DESCRIPTION
# Description

Separate the init and add the command

## Issue ticket number and link
[ROV-60](https://linear.app/antstack/issue/ROV-60/separate-the-rover-init-command)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## New Packages

1.
